### PR TITLE
Fix resolving package name in "required by" field of the bellow packages table

### DIFF
--- a/src/UpdateRequestPlugin.php
+++ b/src/UpdateRequestPlugin.php
@@ -6,6 +6,7 @@ use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Factory as ComposerFactory;
 use Composer\IO\IOInterface;
+use Composer\Package\Package;
 use Composer\Repository\BaseRepository;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
@@ -244,11 +245,16 @@ class UpdateRequestPlugin implements PluginInterface, EventSubscriberInterface
         /** @var BaseRepository $repository */
         $repository = $this->composer->getRepositoryManager()->getLocalRepository();
         foreach ($diff as $name => $ver) {
-            $why = $repository->getDependents($name);
+            $why = array_map(function (array $dependent) {
+                /** @var Package $package */
+                list($package) = $dependent;
+
+                return $package->getName();
+            }, $repository->getDependents($name));
             $content .= sprintf(
                 '| %s | %s | %s | %s |' . PHP_EOL,
                 $name,
-                implode("<br>", array_keys($why)),
+                implode("<br>", array_unique($why)),
                 $this->before[$name] ?? '--',
                 $ver
             );


### PR DESCRIPTION
When use composer v1.9.1, breaked resolving package name.

before:
![image](https://user-images.githubusercontent.com/1389856/71058475-4c32b980-21a3-11ea-981d-a1b637ad6348.png)

after:
![image](https://user-images.githubusercontent.com/1389856/71058572-9ddb4400-21a3-11ea-8d41-c6d09df53d59.png)

## appendix
https://github.com/composer/composer/compare/1.9.0...1.9.1
![image](https://user-images.githubusercontent.com/1389856/70998987-d6cfd600-211b-11ea-82e8-aa01ff3bc281.png)
